### PR TITLE
test for base case, support case sensitivity

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,17 @@
 'use strict';
 
-function fuzzysearch (query, text) {
-  var i;
-  var character;
-  var currentIndex;
-  var lastIndex = -1;
-  for (i = 0; i < query.length; i++) {
-    character = query[i];
-    currentIndex = text.indexOf(character, lastIndex + 1);
-    if (currentIndex === -1) {
-      return false;
-    }
-    lastIndex = currentIndex;
+function fuzzysearch (query, text, cs) {
+  var li = -1;
+  query = cs ? query : query.toLowerCase();
+  text = cs ? text : text.toLowerCase();
+  if (text.indexOf(query) > li) {
+    return true;
   }
-  return true;
-}
+  return query.split('').every(function (char) {
+    var i = text.indexOf(char, li + 1);
+    var t = li < i;
+    return (li = i, t);
+  });
+};
 
 module.exports = fuzzysearch;

--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ function fuzzysearch (query, text, cs) {
     var t = li < i;
     return (li = i, t);
   });
-};
+}
 
 module.exports = fuzzysearch;

--- a/test/fuzzysearch.js
+++ b/test/fuzzysearch.js
@@ -10,5 +10,7 @@ test('fuzzysearch should match expectations', function (t) {
   t.equal(fuzzysearch('cartwheel', 'cartwheel'), true);
   t.equal(fuzzysearch('cwheeel', 'cartwheel'), false);
   t.equal(fuzzysearch('lw', 'cartwheel'), false);
+  t.equal(fuzzysearch('cart', 'Cartwheel'), true);
+  t.equal(fuzzysearch('cart', 'Cartwheel', true), false);
   t.end();
 });


### PR DESCRIPTION
Testing for the base case should speed things up a bit. For example if the query is "cart" and the text is "cartwheel" we would not have to loop through each character. I also added support for case sensitivity. This way if the query is "cart" and the text is "Cartwheel" we still get true.