### PR TITLE
Improved breaker for equal-length query & text

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ function fuzzysearch (query, text) {
   if (qlen > tlen) {
     return false;
   }
-  if (qlen === tlen && query === text) {
-    return true;
+  if (qlen === tlen) {
+    return query === text;
   }
   outer: for (var i = 0, j = 0; i < qlen; i++) {
     var qch = query.charCodeAt(i);


### PR DESCRIPTION
If the lengths are equal but the query does not equal the text, there is no way the query will match the text.
Closes #8