### PR TITLE
Curry the fuzzysearch method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,32 @@
 'use strict';
 
 function fuzzysearch (needle, haystack) {
-  var hlen = haystack.length;
-  var nlen = needle.length;
-  if (nlen > hlen) {
-    return false;
-  }
-  if (nlen === hlen) {
-    return needle === haystack;
-  }
-  outer: for (var i = 0, j = 0; i < nlen; i++) {
-    var nch = needle.charCodeAt(i);
-    while (j < hlen) {
-      if (haystack.charCodeAt(j++) === nch) {
-        continue outer;
-      }
+  function test (haystack) {
+    var hlen = haystack.length;
+    var nlen = needle.length;
+    if (nlen > hlen) {
+      return false;
     }
-    return false;
+    if (nlen === hlen) {
+      return needle === haystack;
+    }
+    outer: for (var i = 0, j = 0; i < nlen; i++) {
+      var nch = needle.charCodeAt(i);
+      while (j < hlen) {
+        if (haystack.charCodeAt(j++) === nch) {
+          continue outer;
+        }
+      }
+      return false;
+    }
+    return true;
   }
-  return true;
+
+  if (typeof haystack === 'undefined') {
+    return test;
+  }
+
+  return test(haystack);
 }
 
 module.exports = fuzzysearch;

--- a/test/fuzzysearch.js
+++ b/test/fuzzysearch.js
@@ -12,3 +12,17 @@ test('fuzzysearch should match expectations', function (t) {
   t.equal(fuzzysearch('lw', 'cartwheel'), false);
   t.end();
 });
+
+test('fuzzysearch should curry', function (t) {
+  var test = fuzzysearch('car');
+  t.equal(test('cartwheel'), true);
+  t.equal(test('boatwheel'), false);
+
+  var things = ['cartwheel', 'boatwheel', 'wheels on the bus', 'car tire'];
+  var result = things.map(test);
+  t.deepEqual(result, [true, false, false, true]);
+
+  var otherResult = things.filter(test);
+  t.deepEqual(otherResult, ['cartwheel', 'car tire']);
+  t.end();
+});


### PR DESCRIPTION
This PR curries the fuzzysearch method if you pass only one argument. With it you can pass it to array.filter like so:
```javascript
var stuff = ['cartwheel', 'boatwheel', 'wheels on the bus', 'car tire'];
var results = stuff.filter(fuzzysearch('car'));
console.log(results); // ['cartwheel', 'car tire']
```

The existing uncurried two argument API is exactly the same.