### PR TITLE
add testcase for chinese unicode

### DIFF
--- a/test/fuzzysearch.js
+++ b/test/fuzzysearch.js
@@ -10,5 +10,17 @@ test('fuzzysearch should match expectations', function (t) {
   t.equal(fuzzysearch('cartwheel', 'cartwheel'), true);
   t.equal(fuzzysearch('cwheeel', 'cartwheel'), false);
   t.equal(fuzzysearch('lw', 'cartwheel'), false);
+
+  // chinese unicode testcase
+  t.equal(fuzzysearch('语言', 'php语言'), true);
+  t.equal(fuzzysearch('hp语', 'php语言'), true);
+  t.equal(fuzzysearch('Py开发', 'Python开发者'), true);
+  t.equal(fuzzysearch('Py 开发', 'Python开发者'), false);
+  t.equal(fuzzysearch('爪哇进阶', '爪哇开发进阶'), true);
+  t.equal(fuzzysearch('格式工具', '非常简单的格式化工具'), true);
+  t.equal(fuzzysearch('正则', '学习正则表达式怎么学习'), true);
+  t.equal(fuzzysearch('学习正则', '正则表达式怎么学习'), false);
+  // end chinese unicode testcase
+
   t.end();
 });


### PR DESCRIPTION
I will use it in my website(`Chinese`), But not sure whether supports `Chinese`, so add testcases for it. nice work, all passed.

But I download the demo [http://bevacqua.github.io/horsey/](http://bevacqua.github.io/horsey/), add Chinese Options, it can not support. Maybe it is a bug of  the demo site. 

See Below:

`search one letter`
![image](https://cloud.githubusercontent.com/assets/7856674/15349251/04ba44da-1d04-11e6-854d-b1621791e4d5.png)

`search two letter`
![image](https://cloud.githubusercontent.com/assets/7856674/15349258/19b446d8-1d04-11e6-965a-d014df3055e4.png)

**it show give the same option**

the demo website make me confused, after the testcases, I believe it is the bug of demo website.
