### PR TITLE
Add typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+declare namespace fuzzysearch {
+
+}
+
+/**
+ * The method will return true only if each character in the needle can be found in the haystack and occurs after the preceding matches.
+ * @param needle {string} the search value you're looking for
+ * @param haystack {string} find one or more occurrences of the "needle" within the "haystack"
+ * @example fuzzysearch('twl', 'cartwheel') // <- true
+ * @returns {boolean} `true` if needle matches haystack using a fuzzy-searching algorithm
+ */
+declare function fuzzysearch(needle: string, haystack: string): boolean;
+
+export = fuzzysearch;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "ng@bevacqua.io",
     "url": "http://bevacqua.io"
   },
+  "typings": "./index.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,

I would like to contribute with typescript definition file (`index.d.ts`) to project. 

There's no typings in DefinetelyTyped and TS project has to create their own `d.ts` everytime. So, instead of  creating PR to DefinitelyTyped, it makes more sense to create PR directly to this Repo, because repo wasn't updated for a while and it is not going (probably) to change API.

Several IDEs would also benefits from this and they will be able to provide intellisense for user. This is not only exclusive for Typescript devs but it could be used for JS aswell.