### PR TITLE
startsWith Optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function fuzzysearch (needle, haystack) {
     return false;
   }
   if (nlen === hlen) {
-    return needle === haystack;
+    return haystack.startsWith(needle);
   }
   outer: for (var i = 0, j = 0; i < nlen; i++) {
     var nch = needle.charCodeAt(i);


### PR DESCRIPTION
I've made a minor optimization here to improve performance. 

In this new code startsWith() can stop checking as soon as it finds a character that doesn't match, while the former equality comparison checks the entire string. 

The behavior of startsWith() and the equality comparison operator are equivalent when the lengths of the needle and haystack are the same, which the if block assures us of.